### PR TITLE
refactor: move colors into partial

### DIFF
--- a/components/apprentice-qualities/apprentice-qualities.module.scss
+++ b/components/apprentice-qualities/apprentice-qualities.module.scss
@@ -1,9 +1,8 @@
-$c-highlight-green: #01F5AC;
+@use '../../styles/colors' as *;
 
 .primary {
   color: $c-highlight-green;
 }
-
 
 .apprentice-qualities {
   width: 100%;
@@ -52,7 +51,7 @@ $c-highlight-green: #01F5AC;
     position: relative;
     padding-top: 3rem;
     background:
-      linear-gradient(180deg, #0A0A0A, 33%, transparent),
+      linear-gradient(180deg, $background-color, 33%, transparent),
       url('../../public/apprentice-qualities-background.svg'),
       url('../../public/apprentice-qualities-background.svg'),
       url('../../public/apprentice-qualities-background.svg');

--- a/components/hero/hero.module.scss
+++ b/components/hero/hero.module.scss
@@ -1,8 +1,4 @@
-// TODO: Move variables and utilities to another file
-
-$c-highlight-pink: #FE3CB0;
-$c-highlight-blue: #45e6fe;
-$c-highlight-green: #01F5AC;
+@use '../../styles/colors' as *;
 
 @mixin visually-hidden {
   position: fixed;
@@ -153,7 +149,7 @@ $c-highlight-green: #01F5AC;
         grid-area: 13 / 39 / 15 / 44;
 
         circle {
-          stroke: rgb(40, 242, 252);
+          stroke: $c-highlight-blue;
           stroke-width: 1.5;
         }
       }

--- a/components/link/link.module.scss
+++ b/components/link/link.module.scss
@@ -1,4 +1,6 @@
+@use '../../styles/colors' as *;
+
 .link {
-  color: #FFF;
+  color: $primary-text-color;
   margin-right: 3px;
 }

--- a/styles/_colors.scss
+++ b/styles/_colors.scss
@@ -1,0 +1,5 @@
+$background-color: #0A0A0A;
+$primary-text-color: #FFFFFF;
+$c-highlight-green: #01F5AC;
+$c-highlight-pink: #FE3CB0;
+$c-highlight-blue: #45e6fe;

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -1,3 +1,5 @@
+@use 'colors' as *;
+
 @mixin smooth-font {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -20,7 +22,11 @@ body {
     Droid Sans,
     Helvetica Neue,
     sans-serif;
-  background-color: #0A0A0A;
+  color: $primary-text-color;
+}
+
+html {
+  background-color: $background-color;
 }
 
 body {


### PR DESCRIPTION
## Description

- Move color variables into _colors.scss
- Refactor all modues to @use the color partial

FSA21V2-135

### Spec

See Story: [FSA21V2-135](https://sparkbox.atlassian.net/browse/FSA21V2-135)

## To Test

1. Make sure all PR Checks have passed (Github Actions, Netlify etc).
2. Pull down all related branches.
3. Confirm all tests pass: `npm run test:ci`
4. Confirm all lintes pass: 'npm run lint'

## Validation

The following has been completed by the developer:

- [x] This PR has code changes, and our linters still pass.
