### PR TITLE
feat: add previous apprentices group

### DIFF
--- a/components/apprentice-status-indicator/apprentice-status-indicator.js
+++ b/components/apprentice-status-indicator/apprentice-status-indicator.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './apprentice-status-indicator.module.scss';
+
+const ApprenticeStatusIndicator = ({ status }) => {
+  if (!status) return null;
+
+  let svgClass;
+  if (status === 'current') {
+    svgClass = 'current-employee-status';
+  }
+
+  if (status === 'previous') {
+    svgClass = 'past-employee-status';
+  }
+
+  return (
+    <svg viewBox="0 0 100 100" className={styles['employee-status']}>
+      <polygon
+        points="50 15, 100 100, 0 100"
+        className={styles[svgClass]}
+        data-testid="status-indicator"
+      />
+    </svg>
+  );
+};
+
+ApprenticeStatusIndicator.propTypes = {
+  status: PropTypes.oneOf(['current', 'previous']),
+};
+
+ApprenticeStatusIndicator.defaultProps = {
+  status: null,
+};
+
+export default ApprenticeStatusIndicator;

--- a/components/apprentice-status-indicator/apprentice-status-indicator.module.scss
+++ b/components/apprentice-status-indicator/apprentice-status-indicator.module.scss
@@ -1,0 +1,20 @@
+@use '../../styles/colors' as *;
+@use '../../styles/spacing' as *;
+@use '../../styles/fonts' as *;
+
+.employee-status {
+  width: 0.75rem;
+  padding-left: 0.5rem;
+  fill: black;
+}
+
+.past-employee-status {
+  stroke: $c-highlight-green;
+  stroke-width: 0.75rem;
+}
+
+.current-employee-status {
+  stroke: $c-highlight-green;
+  stroke-width: 1rem;
+  fill: $c-highlight-green;
+}

--- a/components/apprentice-status-indicator/apprentice-status-indicator.test.js
+++ b/components/apprentice-status-indicator/apprentice-status-indicator.test.js
@@ -1,0 +1,25 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ApprenticeStatusIndicator from './apprentice-status-indicator';
+
+describe('the ApprenticeStatusIndicator component', () => {
+  it('should not render anything when passed nothing', () => {
+    const { container } = render(<ApprenticeStatusIndicator />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('should render a solid triangle when passed "current"', () => {
+    render(<ApprenticeStatusIndicator status="current" />);
+    expect(screen.getByTestId('status-indicator')).toHaveClass('current-employee-status');
+  });
+
+  it('should render a hollow triangle when passed "previous"', () => {
+    render(<ApprenticeStatusIndicator status="previous" />);
+    expect(screen.getByTestId('status-indicator')).toHaveClass('past-employee-status');
+  });
+});

--- a/components/previous-apprentices-group/previous-apprentices-group.js
+++ b/components/previous-apprentices-group/previous-apprentices-group.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './previous-apprentices-group.module.scss';
+
+const makePreviousApprentice = (apprentice) => {
+  let svgStyleClass = '';
+  if (apprentice.status === 'current') svgStyleClass = 'current-employee-svg';
+  if (apprentice.status === 'previous') svgStyleClass = 'past-employee-svg';
+
+  return (
+    <li
+      className={styles['previous-apprentices-group__apprentice']}
+      data-testid={apprentice.name}
+    >
+      {apprentice.name}
+      <svg id="triangle" viewBox="0 0 100 100" className={styles['employee-svg']}>
+        <polygon
+          points="50 15, 100 100, 0 100"
+          className={styles[svgStyleClass]}
+        />
+      </svg>
+    </li>
+  );
+};
+
+const PreviousApprenticesGroup = ({ version, statuses }) => (
+  <section className={styles['previous-apprentices-group']}>
+    <p
+      className={styles['previous-apprentices-group__version']}
+      data-testid={version}
+    >
+      {version}
+    </p>
+    <ul className={styles['previous-apprentices-group__apprentices']}>
+      {statuses.map(makePreviousApprentice)}
+    </ul>
+  </section>
+);
+
+PreviousApprenticesGroup.propTypes = {
+  version: PropTypes.string.isRequired,
+  statuses: PropTypes.arrayOf(PropTypes.shape({
+    name: PropTypes.string,
+    status: PropTypes.oneOf(['current', 'previous']),
+  })).isRequired,
+};
+
+export default PreviousApprenticesGroup;

--- a/components/previous-apprentices-group/previous-apprentices-group.js
+++ b/components/previous-apprentices-group/previous-apprentices-group.js
@@ -1,29 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './previous-apprentices-group.module.scss';
+import ApprenticeStatusIndicator from '../apprentice-status-indicator/apprentice-status-indicator';
 
-const makePreviousApprentice = (apprentice) => {
-  let svgStyleClass = '';
-  if (apprentice.status === 'current') svgStyleClass = 'current-employee-svg';
-  if (apprentice.status === 'previous') svgStyleClass = 'past-employee-svg';
+const makePreviousApprentice = (apprentice) => (
+  <li
+    className={styles['previous-apprentices-group__apprentice']}
+    data-testid={apprentice.name}
+    key={apprentice.name}
+  >
+    {apprentice.name}
+    <ApprenticeStatusIndicator status={apprentice.status} />
+  </li>
+);
 
-  return (
-    <li
-      className={styles['previous-apprentices-group__apprentice']}
-      data-testid={apprentice.name}
-    >
-      {apprentice.name}
-      <svg id="triangle" viewBox="0 0 100 100" className={styles['employee-svg']}>
-        <polygon
-          points="50 15, 100 100, 0 100"
-          className={styles[svgStyleClass]}
-        />
-      </svg>
-    </li>
-  );
-};
-
-const PreviousApprenticesGroup = ({ version, statuses }) => (
+const PreviousApprenticesGroup = ({ version, apprentices }) => (
   <section className={styles['previous-apprentices-group']}>
     <p
       className={styles['previous-apprentices-group__version']}
@@ -31,15 +22,15 @@ const PreviousApprenticesGroup = ({ version, statuses }) => (
     >
       {version}
     </p>
-    <ul className={styles['previous-apprentices-group__apprentices']}>
-      {statuses.map(makePreviousApprentice)}
+    <ul className={styles['previous-apprentices-group__statuses']}>
+      {apprentices.map(makePreviousApprentice)}
     </ul>
   </section>
 );
 
 PreviousApprenticesGroup.propTypes = {
   version: PropTypes.string.isRequired,
-  statuses: PropTypes.arrayOf(PropTypes.shape({
+  apprentices: PropTypes.arrayOf(PropTypes.shape({
     name: PropTypes.string,
     status: PropTypes.oneOf(['current', 'previous']),
   })).isRequired,

--- a/components/previous-apprentices-group/previous-apprentices-group.module.scss
+++ b/components/previous-apprentices-group/previous-apprentices-group.module.scss
@@ -1,0 +1,38 @@
+@use '../../styles/colors' as *;
+@use '../../styles/spacing' as *;
+@use '../../styles/fonts' as *;
+
+.employee-svg {
+  width: 0.75rem;
+  padding-left: 0.5rem;
+  fill: black;
+}
+
+.past-employee-svg {
+  stroke: $c-highlight-green;
+  stroke-width: 0.75rem;
+}
+
+.current-employee-svg {
+  stroke: $c-highlight-green;
+  stroke-width: 1rem;
+  fill: $c-highlight-green;
+}
+
+.previous-apprentices-group {
+  &__version {
+    color: $c-highlight-pink;
+    padding-bottom: 0.5rem;
+  }
+
+  &__apprentices {
+    padding: 0;
+    list-style-type: none;
+  }
+
+  &__apprentice {
+    &:not(&:last-child) {
+      padding-bottom: 0.5rem;
+    }
+  }
+}

--- a/components/previous-apprentices-group/previous-apprentices-group.module.scss
+++ b/components/previous-apprentices-group/previous-apprentices-group.module.scss
@@ -2,30 +2,13 @@
 @use '../../styles/spacing' as *;
 @use '../../styles/fonts' as *;
 
-.employee-svg {
-  width: 0.75rem;
-  padding-left: 0.5rem;
-  fill: black;
-}
-
-.past-employee-svg {
-  stroke: $c-highlight-green;
-  stroke-width: 0.75rem;
-}
-
-.current-employee-svg {
-  stroke: $c-highlight-green;
-  stroke-width: 1rem;
-  fill: $c-highlight-green;
-}
-
 .previous-apprentices-group {
   &__version {
     color: $c-highlight-pink;
     padding-bottom: 0.5rem;
   }
 
-  &__apprentices {
+  &__statuses {
     padding: 0;
     list-style-type: none;
   }

--- a/components/previous-apprentices-group/previous-apprentices-group.test.js
+++ b/components/previous-apprentices-group/previous-apprentices-group.test.js
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PreviousApprenticesGroup from './previous-apprentices-group';
+
+describe('the Apprentice component', () => {
+  const apprenticeClassSevenApprentices = [
+    { name: 'Betty Baker' },
+    {
+      name: 'Heather Taylor',
+      status: 'previous',
+    },
+  ];
+
+  const apprenticeClassEightApprentices = [
+    {
+      name: 'Yosevu Kilonzo',
+      status: 'current',
+    },
+    {
+      name: 'Corinne Ling',
+      status: 'previous',
+    },
+    {
+      name: 'Travis Sanon',
+      status: 'current',
+    },
+  ];
+
+  it('renders class seven correctly', () => {
+    render(<PreviousApprenticesGroup
+      version="7.0"
+      statuses={apprenticeClassSevenApprentices}
+    />);
+
+    expect(screen.getByTestId('7.0')).toBeTruthy();
+    expect(screen.getByTestId('Betty Baker')).toBeTruthy();
+    expect(screen.getByTestId('Heather Taylor')).toBeTruthy();
+  });
+
+  it('renders class eight correctly', () => {
+    render(<PreviousApprenticesGroup
+      version="8.0"
+      statuses={apprenticeClassEightApprentices}
+    />);
+
+    expect(screen.getByTestId('8.0')).toBeTruthy();
+    expect(screen.getByTestId('Yosevu Kilonzo')).toBeTruthy();
+    expect(screen.getByTestId('Corinne Ling')).toBeTruthy();
+    expect(screen.getByTestId('Travis Sanon')).toBeTruthy();
+  });
+});

--- a/components/previous-apprentices-group/previous-apprentices-group.test.js
+++ b/components/previous-apprentices-group/previous-apprentices-group.test.js
@@ -7,7 +7,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import PreviousApprenticesGroup from './previous-apprentices-group';
 
-describe('the Apprentice component', () => {
+describe('the PreviousApprenticesGroup component', () => {
   const apprenticeClassSevenApprentices = [
     { name: 'Betty Baker' },
     {
@@ -34,7 +34,7 @@ describe('the Apprentice component', () => {
   it('renders class seven correctly', () => {
     render(<PreviousApprenticesGroup
       version="7.0"
-      statuses={apprenticeClassSevenApprentices}
+      apprentices={apprenticeClassSevenApprentices}
     />);
 
     expect(screen.getByTestId('7.0')).toBeTruthy();
@@ -45,7 +45,7 @@ describe('the Apprentice component', () => {
   it('renders class eight correctly', () => {
     render(<PreviousApprenticesGroup
       version="8.0"
-      statuses={apprenticeClassEightApprentices}
+      apprentices={apprenticeClassEightApprentices}
     />);
 
     expect(screen.getByTestId('8.0')).toBeTruthy();

--- a/pages/components.js
+++ b/pages/components.js
@@ -4,12 +4,36 @@ import Apprentice from '../components/apprentice/apprentice';
 import SocialLinks from '../components/social-links/social-links';
 import ApprenticeQualities from '../components/apprentice-qualities/apprentice-qualities';
 import Hero from '../components/hero/hero';
+import PreviousApprenticesGroup from '../components/previous-apprentices-group/previous-apprentices-group';
 
 const Components = () => {
   const links = [
     { href: 'personal', text: 'Personal' },
     { href: 'https://www.linkedin.com/', text: 'Linkedin' },
     { href: 'https://www.github.com/', text: 'Github' },
+  ];
+
+  const apprenticeClassSevenApprentices = [
+    { name: 'Betty Baker' },
+    {
+      name: 'Heather Taylor',
+      status: 'previous',
+    },
+  ];
+
+  const apprenticeClassEightApprentices = [
+    {
+      name: 'Yosevu Kilonzo',
+      status: 'current',
+    },
+    {
+      name: 'Corinne Ling',
+      status: 'previous',
+    },
+    {
+      name: 'Travis Sanon',
+      status: 'current',
+    },
   ];
 
   return (
@@ -27,6 +51,15 @@ const Components = () => {
       <Hero />
       <h2>Apprentice Qualities</h2>
       <ApprenticeQualities />
+      <h2>Previous Apprentices Group</h2>
+      <PreviousApprenticesGroup
+        version="7.0"
+        statuses={apprenticeClassSevenApprentices}
+      />
+      <PreviousApprenticesGroup
+        version="8.0"
+        statuses={apprenticeClassEightApprentices}
+      />
     </main>
   );
 };

--- a/pages/components.js
+++ b/pages/components.js
@@ -54,11 +54,11 @@ const Components = () => {
       <h2>Previous Apprentices Group</h2>
       <PreviousApprenticesGroup
         version="7.0"
-        statuses={apprenticeClassSevenApprentices}
+        apprentices={apprenticeClassSevenApprentices}
       />
       <PreviousApprenticesGroup
         version="8.0"
-        statuses={apprenticeClassEightApprentices}
+        apprentices={apprenticeClassEightApprentices}
       />
     </main>
   );


### PR DESCRIPTION
Adds previous apprentices group component and tests.

References FSA21V2-147

## Description

Adds previous apprentices group component and tests.

### Spec

Designs: https://www.figma.com/file/JcLgjMi1dD3m64Vtfwq0Te/Apprentices?node-id=0%3A1

See Story: [FSA21V2-147](https://sparkbox.atlassian.net/browse/FSA21V2-147)

## To Test

1. Make sure all PR Checks have passed (Github Actions, Netlify etc).
2. Pull down all related branches.
3. Confirm all tests pass: `npm run test:ci`
4. _[continue instructions here]_

_[For an example of good validation instructions, check out [Bryan's Bouncy Ball PR](https://github.com/sparkbox/bouncy-ball/pull/56#issue-192153701).]_

## Validation

The following has been completed by the developer:

- [ ] This PR has visual elements, so it was reviewed by a designer.
- [x] This PR has code changes, and our linters still pass.
- [x] This PR affects production code, so it was browser tested (see below).
- [x] This PR has new code, so new tests were added or updated, and they pass.
- [ ] This PR has copy changes, so copy was proofread and approved.
- [ ] The content of this PR requires documentation, so we added a detailed description of component purpose, requirements, quirks, and instructions for use by designers and developers. Along with accessibility information if pertinent.

### Browser Testing

#### Gold Level Browsers

In these browsers, all content is accessible and design matches exactly. In most cases, bugs should be resolved before merge.

**macOS**

- [ ] Chrome, current release
- [ ] Firefox, current release
- [ ] Safari, current release

**Windows**

- [ ] Chrome, current release
- [ ] Firefox, current release

**Mobile**

- [ ] Chrome on Android 9
- [ ] Safari, current release, on iPhone

#### Silver Level Browsers

In these browsers, all content is readable, but design may be inaccurate.

**Windows**

- [ ] Edge, current release

**Mobile**

- [ ] Android 8 - Chrome on Phone
- [ ] Safari, version before current release, on iPad (including various split screen widths)
- [ ] Chrome on iPhone

#### Bronze Level Browsers

In these browsers, our only goal is content readability.

**Windows**

- [ ] IE 11
