### PR TITLE
feat: Semantic HTML Audit

### DIFF
--- a/__tests__/__snapshots__/snapshot.js.snap
+++ b/__tests__/__snapshots__/snapshot.js.snap
@@ -4,199 +4,199 @@ exports[`renders homepage unchanged 1`] = `
 <div
   className="container"
 >
-  <main>
-    <header
-      className="hero"
+  <header
+    className="hero"
+  >
+    <div
+      className="hero__container"
     >
-      <div
-        className="hero__container"
-      >
-        <div>
+      <div>
+        <svg
+          aria-hidden={true}
+          className="hero__sparkbox-logo--half"
+          fill="none"
+          height="45"
+          width="41"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M9.84 29.708v6.155h1.968l3.635-6.155H9.84Zm20.883-13.35h.027a3.087 3.087 0 0 0 3.089-3.09 3.087 3.087 0 0 0-3.089-3.092h-.793l-3.635 6.155 4.4.028ZM9.84 10.205v7.003l10.387-7.003H9.84Zm20.91 19.504h-1.011l-9.13 6.155H30.75a3.087 3.087 0 0 0 3.089-3.091c0-1.669-1.394-3.064-3.089-3.064Zm9.922-7.358-7.68 5.197a5.706 5.706 0 0 1 3.47 5.252 5.712 5.712 0 0 1-5.712 5.718H16.728l-9.54 6.428c-.054.028-.109.055-.19.055a.316.316 0 0 1-.329-.328c0-.082.028-.137.055-.192l3.526-5.99H7.517a.333.333 0 0 1-.328-.329v-10.75c0-.192.136-.329.328-.329h11.917c.164 0 .328.137.328.328a.395.395 0 0 1-.055.192l-5.576 9.465 18.86-12.748H.328A.316.316 0 0 1 0 23.991c0-.11.055-.219.164-.274l7.052-4.76V7.851c0-.164.164-.3.328-.3h16.564l7.243-4.897 3.854-2.6A.395.395 0 0 1 35.397 0c.191 0 .328.137.328.328a.508.508 0 0 1-.055.192l-4.155 7.085a5.703 5.703 0 0 1 4.975 5.662 5.712 5.712 0 0 1-5.713 5.718h-8.446a.316.316 0 0 1-.328-.328c0-.055.028-.11.028-.165l6.204-10.559L7.845 21.72h32.69c.192 0 .328.137.328.329-.027.136-.082.246-.191.3Z"
+            fill="#fff"
+          />
+        </svg>
+        <a
+          href="https://www.seesparkbox.com"
+        >
+          <span
+            className="hero__header-label"
+          >
+            Sparkbox
+          </span>
           <svg
             aria-hidden={true}
-            className="hero__sparkbox-logo--half"
+            className="hero__sparkbox-logo--full"
             fill="none"
-            height="45"
-            width="41"
+            height="52"
+            width="193"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
-              d="M9.84 29.708v6.155h1.968l3.635-6.155H9.84Zm20.883-13.35h.027a3.087 3.087 0 0 0 3.089-3.09 3.087 3.087 0 0 0-3.089-3.092h-.793l-3.635 6.155 4.4.028ZM9.84 10.205v7.003l10.387-7.003H9.84Zm20.91 19.504h-1.011l-9.13 6.155H30.75a3.087 3.087 0 0 0 3.089-3.091c0-1.669-1.394-3.064-3.089-3.064Zm9.922-7.358-7.68 5.197a5.706 5.706 0 0 1 3.47 5.252 5.712 5.712 0 0 1-5.712 5.718H16.728l-9.54 6.428c-.054.028-.109.055-.19.055a.316.316 0 0 1-.329-.328c0-.082.028-.137.055-.192l3.526-5.99H7.517a.333.333 0 0 1-.328-.329v-10.75c0-.192.136-.329.328-.329h11.917c.164 0 .328.137.328.328a.395.395 0 0 1-.055.192l-5.576 9.465 18.86-12.748H.328A.316.316 0 0 1 0 23.991c0-.11.055-.219.164-.274l7.052-4.76V7.851c0-.164.164-.3.328-.3h16.564l7.243-4.897 3.854-2.6A.395.395 0 0 1 35.397 0c.191 0 .328.137.328.328a.508.508 0 0 1-.055.192l-4.155 7.085a5.703 5.703 0 0 1 4.975 5.662 5.712 5.712 0 0 1-5.713 5.718h-8.446a.316.316 0 0 1-.328-.328c0-.055.028-.11.028-.165l6.204-10.559L7.845 21.72h32.69c.192 0 .328.137.328.329-.027.136-.082.246-.191.3Z"
+              d="M11.225 34.33v7.112h2.245l4.146-7.112h-6.391Zm23.82-15.427h.032c1.933 0 3.523-1.58 3.523-3.572 0-1.96-1.559-3.572-3.523-3.572h-.904l-4.147 7.113 5.02.031Zm-23.82-7.112v8.092l11.848-8.092H11.225ZM35.077 34.33h-1.154L23.51 41.442h11.568c1.933 0 3.523-1.58 3.523-3.572 0-1.928-1.59-3.54-3.523-3.54Zm11.318-8.504-8.762 6.006a6.596 6.596 0 0 1 3.96 6.07c0 3.635-2.9 6.606-6.516 6.606H19.082L8.2 51.937a.446.446 0 0 1-.218.063.363.363 0 0 1-.374-.38c0-.094.03-.157.062-.22l4.022-6.923H8.574a.382.382 0 0 1-.374-.38V31.674c0-.221.156-.38.374-.38H22.17c.187 0 .374.159.374.38a.461.461 0 0 1-.063.221l-6.36 10.938 21.513-14.73H.374a.363.363 0 0 1-.374-.38c0-.127.062-.253.187-.316l8.044-5.5V9.071c0-.19.187-.347.374-.347H27.5l8.263-5.659L40.159.063A.446.446 0 0 1 40.377 0c.218 0 .374.158.374.38a.592.592 0 0 1-.062.22l-4.74 8.188c3.212.41 5.675 3.192 5.675 6.543 0 3.636-2.9 6.607-6.516 6.607h-9.634a.363.363 0 0 1-.375-.38c0-.063.032-.126.032-.189l7.077-12.202L8.948 25.1H46.24c.218 0 .374.158.374.38-.031.158-.093.284-.218.347ZM72.648 19.314l-2.65 1.454c-.406-.885-1.092-2.75-3.274-2.655-1.216.032-2.339 1.233-2.339 2.94 0 1.738.749 2.94 3.15 4.394 3.21 1.991 4.832 4.14 4.832 7.65 0 3.983-2.245 6.764-5.955 6.764-3.742 0-5.425-2.529-6.454-5.563l2.93-1.454c.656 1.643 1.31 3.572 3.15 3.603 1.528.032 2.744-1.106 2.744-2.971 0-1.707-.686-2.94-3.368-4.52-2.837-1.707-4.614-3.983-4.614-7.524 0-3.825 2.65-6.733 5.8-6.733 4.302 0 5.58 3.572 6.048 4.615ZM77.45 15.047h4.707c4.303 0 6.922 3.034 6.922 7.997 0 5.027-2.619 8.125-6.86 8.125h-1.122v8.187H77.45v-24.31Zm3.647 12.644h.842c2.12 0 3.337-1.707 3.337-4.615 0-2.845-1.248-4.52-3.368-4.52h-.81v9.135ZM101.208 33.919H95.97l-1.091 5.468h-3.523l5.269-24.34h4.115l5.207 24.34h-3.648l-1.091-5.468Zm-4.614-3.32h3.991l-1.934-9.704h-.093l-1.964 9.704ZM110.406 15.047h4.427c4.397 0 7.078 2.908 7.078 7.587 0 2.908-.904 5.12-2.557 6.511l3.586 10.242h-3.928l-2.931-8.85c-.468.063-.905.126-1.372.126h-.624v8.724h-3.648v-24.34h-.031Zm3.679 12.17h.561c2.214 0 3.492-1.58 3.492-4.489 0-2.718-1.278-4.172-3.492-4.172h-.561v8.661ZM133.354 29.525l-1.621 3.034v6.797h-3.648v-24.34h3.648V26.71l4.708-11.696h4.053l-4.739 10.653 5.238 13.688h-4.178l-3.461-9.831ZM145.732 15.047h5.457c3.71 0 6.204 2.529 6.204 6.322 0 2.402-1.091 4.489-2.806 5.374 1.933.822 3.212 2.971 3.212 5.627 0 4.204-2.682 6.986-6.61 6.986h-5.426l-.031-24.31Zm3.586 10.463h1.559c1.652 0 2.712-1.454 2.712-3.762 0-2.023-1.06-3.414-2.681-3.414h-1.59v7.176Zm1.621 10.621c1.84 0 3.025-1.517 3.025-3.761 0-2.181-1.185-3.604-3.056-3.604h-1.59v7.365h1.621ZM168.992 39.798c-4.615 0-7.203-4.489-7.203-12.613 0-8.092 2.62-12.55 7.203-12.55 4.614 0 7.202 4.521 7.202 12.614 0 8.092-2.588 12.549-7.202 12.549Zm0-3.667c2.12 0 3.336-3.16 3.336-8.914 0-5.722-1.247-8.883-3.336-8.883-2.151 0-3.336 3.161-3.336 8.883 0 5.753 1.185 8.914 3.336 8.914ZM183.865 27.09l-4.709-12.043h4.147l2.993 8.693 2.775-8.693h3.835l-4.614 12.296L193 39.388h-4.116l-3.024-8.724-2.931 8.724h-3.804l4.74-12.296Z"
               fill="#fff"
             />
           </svg>
-          <a
-            href="https://www.seesparkbox.com"
-          >
-            <span
-              className="hero__header-label"
-            >
-              Sparkbox
-            </span>
-            <svg
-              aria-hidden={true}
-              className="hero__sparkbox-logo--full"
-              fill="none"
-              height="52"
-              width="193"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M11.225 34.33v7.112h2.245l4.146-7.112h-6.391Zm23.82-15.427h.032c1.933 0 3.523-1.58 3.523-3.572 0-1.96-1.559-3.572-3.523-3.572h-.904l-4.147 7.113 5.02.031Zm-23.82-7.112v8.092l11.848-8.092H11.225ZM35.077 34.33h-1.154L23.51 41.442h11.568c1.933 0 3.523-1.58 3.523-3.572 0-1.928-1.59-3.54-3.523-3.54Zm11.318-8.504-8.762 6.006a6.596 6.596 0 0 1 3.96 6.07c0 3.635-2.9 6.606-6.516 6.606H19.082L8.2 51.937a.446.446 0 0 1-.218.063.363.363 0 0 1-.374-.38c0-.094.03-.157.062-.22l4.022-6.923H8.574a.382.382 0 0 1-.374-.38V31.674c0-.221.156-.38.374-.38H22.17c.187 0 .374.159.374.38a.461.461 0 0 1-.063.221l-6.36 10.938 21.513-14.73H.374a.363.363 0 0 1-.374-.38c0-.127.062-.253.187-.316l8.044-5.5V9.071c0-.19.187-.347.374-.347H27.5l8.263-5.659L40.159.063A.446.446 0 0 1 40.377 0c.218 0 .374.158.374.38a.592.592 0 0 1-.062.22l-4.74 8.188c3.212.41 5.675 3.192 5.675 6.543 0 3.636-2.9 6.607-6.516 6.607h-9.634a.363.363 0 0 1-.375-.38c0-.063.032-.126.032-.189l7.077-12.202L8.948 25.1H46.24c.218 0 .374.158.374.38-.031.158-.093.284-.218.347ZM72.648 19.314l-2.65 1.454c-.406-.885-1.092-2.75-3.274-2.655-1.216.032-2.339 1.233-2.339 2.94 0 1.738.749 2.94 3.15 4.394 3.21 1.991 4.832 4.14 4.832 7.65 0 3.983-2.245 6.764-5.955 6.764-3.742 0-5.425-2.529-6.454-5.563l2.93-1.454c.656 1.643 1.31 3.572 3.15 3.603 1.528.032 2.744-1.106 2.744-2.971 0-1.707-.686-2.94-3.368-4.52-2.837-1.707-4.614-3.983-4.614-7.524 0-3.825 2.65-6.733 5.8-6.733 4.302 0 5.58 3.572 6.048 4.615ZM77.45 15.047h4.707c4.303 0 6.922 3.034 6.922 7.997 0 5.027-2.619 8.125-6.86 8.125h-1.122v8.187H77.45v-24.31Zm3.647 12.644h.842c2.12 0 3.337-1.707 3.337-4.615 0-2.845-1.248-4.52-3.368-4.52h-.81v9.135ZM101.208 33.919H95.97l-1.091 5.468h-3.523l5.269-24.34h4.115l5.207 24.34h-3.648l-1.091-5.468Zm-4.614-3.32h3.991l-1.934-9.704h-.093l-1.964 9.704ZM110.406 15.047h4.427c4.397 0 7.078 2.908 7.078 7.587 0 2.908-.904 5.12-2.557 6.511l3.586 10.242h-3.928l-2.931-8.85c-.468.063-.905.126-1.372.126h-.624v8.724h-3.648v-24.34h-.031Zm3.679 12.17h.561c2.214 0 3.492-1.58 3.492-4.489 0-2.718-1.278-4.172-3.492-4.172h-.561v8.661ZM133.354 29.525l-1.621 3.034v6.797h-3.648v-24.34h3.648V26.71l4.708-11.696h4.053l-4.739 10.653 5.238 13.688h-4.178l-3.461-9.831ZM145.732 15.047h5.457c3.71 0 6.204 2.529 6.204 6.322 0 2.402-1.091 4.489-2.806 5.374 1.933.822 3.212 2.971 3.212 5.627 0 4.204-2.682 6.986-6.61 6.986h-5.426l-.031-24.31Zm3.586 10.463h1.559c1.652 0 2.712-1.454 2.712-3.762 0-2.023-1.06-3.414-2.681-3.414h-1.59v7.176Zm1.621 10.621c1.84 0 3.025-1.517 3.025-3.761 0-2.181-1.185-3.604-3.056-3.604h-1.59v7.365h1.621ZM168.992 39.798c-4.615 0-7.203-4.489-7.203-12.613 0-8.092 2.62-12.55 7.203-12.55 4.614 0 7.202 4.521 7.202 12.614 0 8.092-2.588 12.549-7.202 12.549Zm0-3.667c2.12 0 3.336-3.16 3.336-8.914 0-5.722-1.247-8.883-3.336-8.883-2.151 0-3.336 3.161-3.336 8.883 0 5.753 1.185 8.914 3.336 8.914ZM183.865 27.09l-4.709-12.043h4.147l2.993 8.693 2.775-8.693h3.835l-4.614 12.296L193 39.388h-4.116l-3.024-8.724-2.931 8.724h-3.804l4.74-12.296Z"
-                fill="#fff"
-              />
-            </svg>
-          </a>
+        </a>
+      </div>
+      <div
+        className="hero__header-content"
+      >
+        <div
+          className="hero__text"
+        >
+          <h1>
+            Apprenticeships at Sparkbox
+          </h1>
+          <p>
+            Sparkbox is a team that values education. We offer paid apprenticeships because we love what we do, we want to share with new talent, and we genuinely care about the future of the web.
+          </p>
         </div>
         <div
-          className="hero__header-content"
+          aria-hidden={true}
+          className="hero__art-container"
         >
           <div
-            className="hero__text"
+            className="hero__grid"
           >
-            <h1>
-              Apprenticeships at Sparkbox
-            </h1>
-            <p>
-              Sparkbox is a team that values education. We offer paid apprenticeships because we love what we do, we want to share with new talent, and we genuinely care about the future of the web.
-            </p>
-          </div>
-          <div
-            aria-hidden={true}
-            className="hero__art-container"
-          >
+            <img
+              alt=""
+              src="/apprentices/Luis.png"
+            />
+            <img
+              alt=""
+              src="/apprentices/Rise.png"
+            />
+            <img
+              alt=""
+              src="/apprentices/Melissa.png"
+            />
+            <img
+              alt=""
+              src="/apprentices/Flash.png"
+            />
+            <img
+              alt=""
+              src="/apprentices/Susmita.png"
+            />
             <div
-              className="hero__grid"
+              className="hero__grid--shape1"
             >
-              <img
-                alt=""
-                src="/apprentices/Luis.png"
-              />
-              <img
-                alt=""
-                src="/apprentices/Rise.png"
-              />
-              <img
-                alt=""
-                src="/apprentices/Melissa.png"
-              />
-              <img
-                alt=""
-                src="/apprentices/Flash.png"
-              />
-              <img
-                alt=""
-                src="/apprentices/Susmita.png"
-              />
-              <div
-                className="hero__grid--shape1"
+              <svg
+                fill="none"
+                viewBox="0 0 40 34"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  fill="none"
-                  viewBox="0 0 40 34"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M3.00133 32.5401L20.2337 2.69278L37.4661 32.5401H3.00133Z"
-                    stroke="#FE3CB0"
-                  />
-                </svg>
-              </div>
-              <div
-                className="hero__grid--shape2"
+                <path
+                  d="M3.00133 32.5401L20.2337 2.69278L37.4661 32.5401H3.00133Z"
+                  stroke="#FE3CB0"
+                />
+              </svg>
+            </div>
+            <div
+              className="hero__grid--shape2"
+            >
+              <svg
+                fill="none"
+                viewBox="0 0 40 40"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  fill="none"
-                  viewBox="0 0 40 40"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <circle
-                    cx="19.9315"
-                    cy="19.7905"
-                    r="18.2325"
-                    stroke="#01F5AC"
-                  />
-                </svg>
-              </div>
-              <div
-                className="hero__grid--shape3"
+                <circle
+                  cx="19.9315"
+                  cy="19.7905"
+                  r="18.2325"
+                  stroke="#01F5AC"
+                />
+              </svg>
+            </div>
+            <div
+              className="hero__grid--shape3"
+            >
+              <svg
+                fill="none"
+                viewBox="0 0 40 34"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  fill="none"
-                  viewBox="0 0 40 34"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M3.00133 32.5401L20.2337 2.69278L37.4661 32.5401H3.00133Z"
-                    stroke="#FE3CB0"
-                  />
-                </svg>
-              </div>
-              <div
-                className="hero__grid--shape4"
+                <path
+                  d="M3.00133 32.5401L20.2337 2.69278L37.4661 32.5401H3.00133Z"
+                  stroke="#FE3CB0"
+                />
+              </svg>
+            </div>
+            <div
+              className="hero__grid--shape4"
+            >
+              <svg
+                fill="none"
+                viewBox="0 0 40 40"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  fill="none"
-                  viewBox="0 0 40 40"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <circle
-                    cx="19.9315"
-                    cy="19.7905"
-                    r="18.2325"
-                    stroke="#01F5AC"
-                  />
-                </svg>
-              </div>
-              <div
-                className="hero__grid--shape5"
+                <circle
+                  cx="19.9315"
+                  cy="19.7905"
+                  r="18.2325"
+                  stroke="#01F5AC"
+                />
+              </svg>
+            </div>
+            <div
+              className="hero__grid--shape5"
+            >
+              <svg
+                fill="none"
+                viewBox="0 0 40 34"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  fill="none"
-                  viewBox="0 0 40 34"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M3.00133 32.5401L20.2337 2.69278L37.4661 32.5401H3.00133Z"
-                    stroke="#FE3CB0"
-                  />
-                </svg>
-              </div>
-              <div
-                className="hero__grid--shape6"
+                <path
+                  d="M3.00133 32.5401L20.2337 2.69278L37.4661 32.5401H3.00133Z"
+                  stroke="#FE3CB0"
+                />
+              </svg>
+            </div>
+            <div
+              className="hero__grid--shape6"
+            >
+              <svg
+                fill="none"
+                viewBox="0 0 40 40"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  fill="none"
-                  viewBox="0 0 40 40"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <circle
-                    cx="19.9315"
-                    cy="19.7905"
-                    r="18.2325"
-                    stroke="#01F5AC"
-                  />
-                </svg>
-              </div>
-              <div
-                className="hero__grid--shape7"
+                <circle
+                  cx="19.9315"
+                  cy="19.7905"
+                  r="18.2325"
+                  stroke="#01F5AC"
+                />
+              </svg>
+            </div>
+            <div
+              className="hero__grid--shape7"
+            >
+              <svg
+                fill="none"
+                viewBox="0 0 40 34"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  fill="none"
-                  viewBox="0 0 40 34"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M3.00133 32.5401L20.2337 2.69278L37.4661 32.5401H3.00133Z"
-                    stroke="#FE3CB0"
-                  />
-                </svg>
-              </div>
+                <path
+                  d="M3.00133 32.5401L20.2337 2.69278L37.4661 32.5401H3.00133Z"
+                  stroke="#FE3CB0"
+                />
+              </svg>
             </div>
           </div>
         </div>
       </div>
-    </header>
+    </div>
+  </header>
+  <main>
     <section
       className="apprentice-qualities"
     >
@@ -263,16 +263,16 @@ exports[`renders homepage unchanged 1`] = `
           <div
             className="card-container__card"
           >
-            <article
+            <div
               className="container"
             >
-              <h2
+              <h3
                 className="container__heading"
               >
-                First Last
-              </h2>
+                First Last1
+              </h3>
               <img
-                alt="First Last"
+                alt="a portrait of First Last1"
                 className="container__image"
                 src="/apprentices/First.png"
               />
@@ -283,12 +283,14 @@ exports[`renders homepage unchanged 1`] = `
                   className="container"
                 >
                   <a
+                    aria-label="First Last1's Personal"
                     className="link"
                     href="personal"
                   >
                     Personal
                   </a>
                   <svg
+                    aria-hidden={true}
                     fill="none"
                     height="9"
                     viewBox="0 0 11 9"
@@ -307,12 +309,14 @@ exports[`renders homepage unchanged 1`] = `
                   className="container"
                 >
                   <a
+                    aria-label="First Last1's Linkedin"
                     className="link"
                     href="https://www.linkedin.com/"
                   >
                     Linkedin
                   </a>
                   <svg
+                    aria-hidden={true}
                     fill="none"
                     height="9"
                     viewBox="0 0 11 9"
@@ -331,12 +335,14 @@ exports[`renders homepage unchanged 1`] = `
                   className="container"
                 >
                   <a
+                    aria-label="First Last1's Github"
                     className="link"
                     href="https://www.github.com/"
                   >
                     Github
                   </a>
                   <svg
+                    aria-hidden={true}
                     fill="none"
                     height="9"
                     viewBox="0 0 11 9"
@@ -352,21 +358,21 @@ exports[`renders homepage unchanged 1`] = `
                   </svg>
                 </div>
               </div>
-            </article>
+            </div>
           </div>
           <div
             className="card-container__card"
           >
-            <article
+            <div
               className="container"
             >
-              <h2
+              <h3
                 className="container__heading"
               >
-                First Last
-              </h2>
+                First Last2
+              </h3>
               <img
-                alt="First Last"
+                alt="a portrait of First Last2"
                 className="container__image"
                 src="/apprentices/First.png"
               />
@@ -377,12 +383,14 @@ exports[`renders homepage unchanged 1`] = `
                   className="container"
                 >
                   <a
+                    aria-label="First Last2's Personal"
                     className="link"
                     href="personal"
                   >
                     Personal
                   </a>
                   <svg
+                    aria-hidden={true}
                     fill="none"
                     height="9"
                     viewBox="0 0 11 9"
@@ -401,12 +409,14 @@ exports[`renders homepage unchanged 1`] = `
                   className="container"
                 >
                   <a
+                    aria-label="First Last2's Linkedin"
                     className="link"
                     href="https://www.linkedin.com/"
                   >
                     Linkedin
                   </a>
                   <svg
+                    aria-hidden={true}
                     fill="none"
                     height="9"
                     viewBox="0 0 11 9"
@@ -425,12 +435,14 @@ exports[`renders homepage unchanged 1`] = `
                   className="container"
                 >
                   <a
+                    aria-label="First Last2's Github"
                     className="link"
                     href="https://www.github.com/"
                   >
                     Github
                   </a>
                   <svg
+                    aria-hidden={true}
                     fill="none"
                     height="9"
                     viewBox="0 0 11 9"
@@ -446,15 +458,15 @@ exports[`renders homepage unchanged 1`] = `
                   </svg>
                 </div>
               </div>
-            </article>
+            </div>
           </div>
         </div>
       </div>
     </section>
-    <article
+    <section
       className="previous-apprentices"
     >
-      <section
+      <div
         className="previous-apprentices__header"
       >
         <h2>
@@ -496,34 +508,41 @@ exports[`renders homepage unchanged 1`] = `
             </p>
           </div>
         </div>
-      </section>
+      </div>
       <div
         className="previous-apprentices__groups"
       >
         <section
           className="previous-apprentices-group"
         >
-          <p
+          <h3
+            aria-label="Previous apprentices group version 0.0"
             className="previous-apprentices-group__version"
             data-testid="0.0"
           >
             0.0
-          </p>
+          </h3>
           <ul
             className="previous-apprentices-group__statuses"
           >
             <li
               className="previous-apprentices-group__apprentice"
-              data-testid="First Last"
+              data-testid="First Last1"
             >
-              First Last
+              First Last1
             </li>
             <li
               className="previous-apprentices-group__apprentice"
-              data-testid="First Last"
+              data-testid="First Last2"
             >
-              First Last
+              First Last2
+              <span
+                className="status-label"
+              >
+                previous employee
+              </span>
               <svg
+                aria-hidden={true}
                 className="employee-status"
                 viewBox="0 0 100 100"
               >
@@ -536,10 +555,16 @@ exports[`renders homepage unchanged 1`] = `
             </li>
             <li
               className="previous-apprentices-group__apprentice"
-              data-testid="First Last"
+              data-testid="First Last3"
             >
-              First Last
+              First Last3
+              <span
+                className="status-label"
+              >
+                current employee
+              </span>
               <svg
+                aria-hidden={true}
                 className="employee-status"
                 viewBox="0 0 100 100"
               >
@@ -553,7 +578,7 @@ exports[`renders homepage unchanged 1`] = `
           </ul>
         </section>
       </div>
-    </article>
+    </section>
     <footer
       className="call-to-action"
     >

--- a/__tests__/snapshot.js
+++ b/__tests__/snapshot.js
@@ -8,7 +8,7 @@ it('renders homepage unchanged', () => {
       version: '0.0',
       currentApprentices: [
         {
-          name: 'First Last',
+          name: 'First Last1',
           image: '/apprentices/First.png',
           links: [
             { href: 'personal', text: 'Personal' },
@@ -17,7 +17,7 @@ it('renders homepage unchanged', () => {
           ],
         },
         {
-          name: 'First Last',
+          name: 'First Last2',
           image: '/apprentices/First.png',
           links: [
             { href: 'personal', text: 'Personal' },
@@ -31,14 +31,14 @@ it('renders homepage unchanged', () => {
       version: '0.0',
       apprentices: [
         {
-          name: 'First Last',
+          name: 'First Last1',
         },
         {
-          name: 'First Last',
+          name: 'First Last2',
           status: 'previous',
         },
         {
-          name: 'First Last',
+          name: 'First Last3',
           status: 'current',
         },
       ],

--- a/components/apprentice-status-indicator/apprentice-status-indicator.js
+++ b/components/apprentice-status-indicator/apprentice-status-indicator.js
@@ -15,13 +15,18 @@ const ApprenticeStatusIndicator = ({ status }) => {
   }
 
   return (
-    <svg viewBox="0 0 100 100" className={styles['employee-status']}>
-      <polygon
-        points="50 15, 100 100, 0 100"
-        className={styles[svgClass]}
-        data-testid="status-indicator"
-      />
-    </svg>
+    <>
+      <span className={styles['status-label']}>
+        { `${status} employee` }
+      </span>
+      <svg viewBox="0 0 100 100" className={styles['employee-status']} aria-hidden>
+        <polygon
+          points="50 15, 100 100, 0 100"
+          className={styles[svgClass]}
+          data-testid="status-indicator"
+        />
+      </svg>
+    </>
   );
 };
 

--- a/components/apprentice-status-indicator/apprentice-status-indicator.module.scss
+++ b/components/apprentice-status-indicator/apprentice-status-indicator.module.scss
@@ -1,6 +1,11 @@
 @use '../../styles/colors' as *;
 @use '../../styles/spacing' as *;
 @use '../../styles/fonts' as *;
+@use '../../styles/mixins' as *;
+
+.status-label {
+  @include visually-hidden();
+}
 
 .employee-status {
   width: 0.75rem;

--- a/components/apprentice/apprentice.js
+++ b/components/apprentice/apprentice.js
@@ -4,13 +4,13 @@ import SocialLinks, { linksPropTypes } from '../social-links/social-links';
 import styles from './apprentice.module.scss';
 
 const Apprentice = ({ image, name, links }) => (
-  <article className={styles.container}>
-    <h2 className={styles.container__heading}>{ name }</h2>
-    <img className={styles.container__image} src={image} alt={name} />
+  <div className={styles.container}>
+    <h3 className={styles.container__heading}>{ name }</h3>
+    <img className={styles.container__image} src={image} alt={`a portrait of ${name}`} />
     <div className={styles.container__links}>
-      <SocialLinks links={links} />
+      <SocialLinks links={links} name={name} />
     </div>
-  </article>
+  </div>
 );
 
 export const apprenticePropTypes = {

--- a/components/apprentice/apprentice.test.js
+++ b/components/apprentice/apprentice.test.js
@@ -34,7 +34,7 @@ describe('the Apprentice component', () => {
   });
 
   it('adds name prop as alt attribute to image', () => {
-    expect(image).toHaveAttribute('alt', 'First Last');
+    expect(image).toHaveAttribute('alt', 'a portrait of First Last');
   });
 
   it('renders links props given an href and text in the correct order', () => {

--- a/components/call-to-action/call-to-action.module.scss
+++ b/components/call-to-action/call-to-action.module.scss
@@ -202,7 +202,7 @@
 
     &__grid {
       width: 90%;
-      grid-template-columns: repeat(67, 1fr);
+      grid-template-columns: repeat(65, 1fr);
       grid-template-rows: repeat(13, 1fr);
 
       img {

--- a/components/hero/hero.module.scss
+++ b/components/hero/hero.module.scss
@@ -65,7 +65,7 @@
 
     &__grid {  // This grid is for the hero images and svgs
       display: grid;
-      grid-template-columns: repeat(65, 1fr);
+      grid-template-columns: repeat(63, 1fr);
       grid-template-rows: repeat(11, 1fr);
 
       img {
@@ -212,7 +212,6 @@
 
     &__sparkbox-logo {
       &--full {
-        padding: 1rem;
         margin-bottom: 0;
       }
     }
@@ -224,7 +223,6 @@
     &__text {
       width: 100%;
       order: 0;
-      padding: 1rem;
       margin-top: 2rem;
 
       h1 {

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -2,12 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './link.module.scss';
 
-const Link = ({ href, children }) => (
-  <a className={styles.link} href={href}>{children}</a>
+const Link = ({ href, ariaLabel, children }) => (
+  <a className={styles.link} href={href} aria-label={ariaLabel}>{children}</a>
 );
 
 Link.propTypes = {
   href: PropTypes.string.isRequired,
+  ariaLabel: PropTypes.string.isRequired,
   children: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
 };
 

--- a/components/link/link.test.js
+++ b/components/link/link.test.js
@@ -9,12 +9,17 @@ import Link from './link';
 
 describe('the Link component', () => {
   it('renders a link with the correct href given an href prop', () => {
-    render(<Link href="http://some/url">hello!</Link>);
+    render(<Link href="http://some/url" ariaLabel="test link">hello</Link>);
     expect(screen.getByRole('link')).toHaveAttribute('href', 'http://some/url');
   });
 
-  it('renders a link given an href and text', () => {
-    render(<Link href="http://some/url">hello!</Link>);
+  it('renders a link with the correct aria-label given an ariaLabel prop', () => {
+    render(<Link href="http://some/url" ariaLabel="test link">hello</Link>);
+    expect(screen.getByRole('link')).toHaveAttribute('aria-label', 'test link');
+  });
+
+  it('renders a link with the correct inner text', () => {
+    render(<Link href="http://some/url" ariaLabel="test link">hello</Link>);
     expect(screen.getByRole('link')).toHaveTextContent('hello');
   });
 });

--- a/components/previous-apprentices-group/previous-apprentices-group.js
+++ b/components/previous-apprentices-group/previous-apprentices-group.js
@@ -16,12 +16,13 @@ const makePreviousApprentice = (apprentice) => (
 
 const PreviousApprenticesGroup = ({ version, apprentices }) => (
   <section className={styles['previous-apprentices-group']}>
-    <p
+    <h3
       className={styles['previous-apprentices-group__version']}
+      aria-label={`Previous apprentices group version ${version}`}
       data-testid={version}
     >
       {version}
-    </p>
+    </h3>
     <ul className={styles['previous-apprentices-group__statuses']}>
       {apprentices.map(makePreviousApprentice)}
     </ul>

--- a/components/previous-apprentices/previous-apprentices.js
+++ b/components/previous-apprentices/previous-apprentices.js
@@ -4,8 +4,8 @@ import styles from './previous-apprentices.module.scss';
 import PreviousApprenticesGroup from '../previous-apprentices-group/previous-apprentices-group';
 
 const PreviousApprentices = ({ previousApprenticeGroups }) => (
-  <article className={styles['previous-apprentices']}>
-    <section className={styles['previous-apprentices__header']}>
+  <section className={styles['previous-apprentices']}>
+    <div className={styles['previous-apprentices__header']}>
       <h2>Previous Apprentices</h2>
       <div className={styles['previous-apprentices__legend']}>
         <div className={styles['previous-apprentices__legend-item']}>
@@ -27,7 +27,7 @@ const PreviousApprentices = ({ previousApprenticeGroups }) => (
           <p>Past Employee</p>
         </div>
       </div>
-    </section>
+    </div>
     <div className={styles['previous-apprentices__groups']}>
       {
         previousApprenticeGroups.map(({ version, apprentices }) => (
@@ -40,7 +40,7 @@ const PreviousApprentices = ({ previousApprenticeGroups }) => (
         ))
       }
     </div>
-  </article>
+  </section>
 );
 
 export const previousApprenticeGroupsPropTypes = PropTypes.shape({

--- a/components/social-links/social-links.js
+++ b/components/social-links/social-links.js
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 import Link from '../link/link';
 import styles from './social-links.module.scss';
 
-const SocialLinks = ({ links }) => (
+const SocialLinks = ({ links, name }) => (
   <>
     { links.map(({ href, text }) => (
       <div className={styles.container} key={href}>
-        <Link href={href}>{ text }</Link>
-        <svg width="11" height="9" viewBox="0 0 11 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <Link href={href} ariaLabel={`${name}'s ${text}`}>{ text }</Link>
+        <svg width="11" height="9" viewBox="0 0 11 9" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden>
           <path fillRule="evenodd" clipRule="evenodd" d="M0.5 3.07343L0.5 8.5L1.26923 8.5L1.26923 3.07343L8.31903 3.07343C7.95887 3.47125 7.57203 4.06799 7.15851 4.86364L7.85883 4.86364C8.6992 3.94367 9.57959 3.27234 10.5 2.84965L10.5 2.51399C9.57959 2.07887 8.6992 1.40754 7.85883 0.500001L7.15852 0.500001C7.57203 1.29565 7.95887 1.89239 8.31903 2.29021L0.5 2.29021L0.5 2.68182L0.5 3.07343Z" fill="white" />
         </svg>
       </div>
@@ -23,6 +23,7 @@ export const linksPropTypes = PropTypes.arrayOf(PropTypes.shape({
 
 SocialLinks.propTypes = {
   links: linksPropTypes,
+  name: PropTypes.string.isRequired,
 };
 
 SocialLinks.defaultProps = {

--- a/components/social-links/social-links.test.js
+++ b/components/social-links/social-links.test.js
@@ -9,26 +9,33 @@ import SocialLinks from './social-links';
 
 describe('the Link component', () => {
   it('renders nothing when passed empty array', async () => {
-    const { container } = render(<SocialLinks links={[]} />);
+    const { container } = render(<SocialLinks links={[]} name="name" />);
     expect(container.innerHTML).toBe('');
   });
 
   it('renders nothing when links is not defined', async () => {
-    const { container } = render(<SocialLinks />);
+    const { container } = render(<SocialLinks name="name" />);
     expect(container.innerHTML).toBe('');
   });
 
-  it('renders links given an href and text in the correct order', () => {
+  it('renders multiple social links in the correct order', () => {
     render(<SocialLinks
       links={[
         { href: 'https://www.facebook.com/', text: 'facebook' },
         { href: 'https://www.google.com/', text: 'google' },
       ]}
+      name="name"
     />);
     const links = screen.getAllByRole('link');
-    expect(links[0]).toHaveAttribute('href', 'https://www.facebook.com/');
     expect(links[0]).toHaveTextContent('facebook');
-    expect(links[1]).toHaveAttribute('href', 'https://www.google.com/');
     expect(links[1]).toHaveTextContent('google');
+  });
+
+  it('renders a social link', () => {
+    render(<SocialLinks links={[{ href: 'https://www.linkedin.com/', text: 'LinkedIn' }]} name="First Last" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveTextContent('LinkedIn');
+    expect(link).toHaveAttribute('href', 'https://www.linkedin.com/');
+    expect(link).toHaveAttribute('aria-label', "First Last's LinkedIn");
   });
 });

--- a/pages/index.js
+++ b/pages/index.js
@@ -24,9 +24,8 @@ const Home = ({ apprenticeData: { currentApprenticeGroup, previousApprenticeGrou
       <title>Sparkbox Apprentices</title>
       <link rel="icon" href="/favicon.ico" />
     </Head>
-
+    <Hero />
     <main>
-      <Hero />
       <ApprenticeQualities />
       <CurrentApprentices currentApprenticeClass={currentApprenticeGroup} />
       <PreviousApprentices previousApprenticeGroups={previousApprenticeGroups} />


### PR DESCRIPTION
## Description

- Apprentice cmp
	- article to div
	- h2 to h3
	- pass name prop to SocialLinks for link aria labels
	- update test to reflect new alt text for images
- Apprentice Status cmp
	-  Add visually hidden span that will act as label for employee status
- Link cmp
	- Use name prop to create dynamic aria labels for a tag
	- update tests
- Previous Apprentice cmp
	- article to section
	- section to div
	- add z-index to scss module (padding was covering current apprentice links)
- Previous Apprentice Group cmp
	- p to h3
	- add aria label to label apprentice group version
- SocialLinks cmp
	- take passed in name prop and pass it into Link cmp
	- update tests
- Home Page
	- move hero outside of main tag
- Updated snapshot

FSA21V2-163

### Spec

See Story: [FSA21V2-163](https://sparkbox.atlassian.net/browse/FSA21V2-163)

## To Test

1. Make sure all PR Checks have passed (Github Actions, Netlify etc).
2. Pull down all related branches.
3. Confirm all tests pass: `npm run test:ci`