### PR TITLE
fix: CTA Links are usable at all screen sizes

### DIFF
--- a/__tests__/__snapshots__/snapshot.js.snap
+++ b/__tests__/__snapshots__/snapshot.js.snap
@@ -608,16 +608,20 @@ exports[`renders homepage unchanged 1`] = `
           <p>
             Take a dive into our world as you learn what it takes to build a better web. Sign up for our monthly newsletter to be notified when applications open, or you can check out our careers page for all currently available positions.
           </p>
-          <a
-            href="https://sparkbox.us1.list-manage.com/subscribe/post?u=c2fcafb7ccc2db34e99075bb1&id=2835f91fa5&f_id=00847ae1f0"
+          <div
+            className="call-to-action__link-container"
           >
-            Newsletter Sign-Up
-          </a>
-          <a
-            href="https://sparkbox.com/careers"
-          >
-            Sparkbox Careers
-          </a>
+            <a
+              href="https://sparkbox.us1.list-manage.com/subscribe/post?u=c2fcafb7ccc2db34e99075bb1&id=2835f91fa5&f_id=00847ae1f0"
+            >
+              Newsletter Sign-Up
+            </a>
+            <a
+              href="https://sparkbox.com/careers"
+            >
+              Sparkbox Careers
+            </a>
+          </div>
         </div>
         <div
           aria-hidden={true}

--- a/components/call-to-action/call-to-action.js
+++ b/components/call-to-action/call-to-action.js
@@ -11,8 +11,10 @@ const CallToAction = () => (
           Sign up for our monthly newsletter to be notified when applications open,
           or you can check out our careers page for all currently available positions.
         </p>
-        <a href="https://sparkbox.us1.list-manage.com/subscribe/post?u=c2fcafb7ccc2db34e99075bb1&id=2835f91fa5&f_id=00847ae1f0">Newsletter Sign-Up</a>
-        <a href="https://sparkbox.com/careers">Sparkbox Careers</a>
+        <div className={styles['call-to-action__link-container']}>
+          <a href="https://sparkbox.us1.list-manage.com/subscribe/post?u=c2fcafb7ccc2db34e99075bb1&id=2835f91fa5&f_id=00847ae1f0">Newsletter Sign-Up</a>
+          <a href="https://sparkbox.com/careers">Sparkbox Careers</a>
+        </div>
       </div>
       <div aria-hidden className={styles['call-to-action__art-container']}>
         <div className={styles['call-to-action__grid']}>

--- a/components/call-to-action/call-to-action.module.scss
+++ b/components/call-to-action/call-to-action.module.scss
@@ -31,18 +31,40 @@
     p {
       margin-bottom: 3rem;
     }
+  }
+
+  &__link-container {
+    $bp-links-move-inline: 37.5rem;
+
+    display: flex;
+    flex-direction: column;
+
+    @media (min-width: $bp-links-move-inline) {
+      flex-direction: row;
+    }
 
     a {
-      width: 15rem;
+      width: 100%;
       padding: 0.5rem;
       font-size: 1.15rem;
       border: 3px white solid;
+      box-sizing: border-box;
       color: white;
       background-color: rgba(0, 0, 0, 0);
       text-decoration: none;
 
+      @media (min-width: $bp-links-move-inline) {
+        width: fit-content;
+        max-width: 15rem;
+      }
+
       & + a {
-        margin-left: 1.4rem;
+        margin-top: 1.5rem;
+
+        @media (min-width: $bp-links-move-inline) {
+          margin-top: 0;
+          margin-left: 1.5rem;
+        }
       }
 
       &:hover {


### PR DESCRIPTION
## Description

The previous addition of a second link to the CTA component was not thoroughly tested at mobile screen sizes (it was me I didn't test it well). This PR ensures the links stack at small screen and have no overlap.

## To Test

1. Make sure all PR Checks have passed (Github Actions, Netlify etc).
2. Pull down all related branches.
3. Confirm all tests pass: `npm run test:ci`
4. Scroll to the bottom CTA and ensure the "Sparkbox Careers" and "Newsletter Sign-Up" buttons aren't looking weird at any screen size. 

## New Hotness
![Screen Shot 2022-09-07 at 10 04 38 AM](https://user-images.githubusercontent.com/7475148/188899446-889dce0b-c710-48fb-bf5f-831c4575779a.png)
![Screen Shot 2022-09-07 at 10 04 45 AM](https://user-images.githubusercontent.com/7475148/188899450-cb6eb1e2-9a36-4c09-9ac2-6454427b5ddd.png)
![Screen Shot 2022-09-07 at 10 04 54 AM](https://user-images.githubusercontent.com/7475148/188899453-53348b13-ceef-4590-9f77-31c3babdfd8b.png)

## Old and Busted
![Screen Shot 2022-09-07 at 10 08 59 AM](https://user-images.githubusercontent.com/7475148/188899572-b9866cfe-8ea0-4eb8-8de0-6a56308b1c22.png)
![Screen Shot 2022-09-07 at 10 09 04 AM](https://user-images.githubusercontent.com/7475148/188899577-2fafd515-9f2d-41ad-b4f3-bdcf4f55258f.png)


