### PR TITLE
feat: Add Google Tag Manager

### DIFF
--- a/__tests__/__snapshots__/snapshot.js.snap
+++ b/__tests__/__snapshots__/snapshot.js.snap
@@ -4,6 +4,13 @@ exports[`renders homepage unchanged 1`] = `
 <div
   className="container"
 >
+  <noscript
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<iframe src=\\"https://www.googletagmanager.com/ns.html?id=GTM-KQ53HCR\\" height=\\"0\\" width=\\"0\\" style=\\"display:none;visibility:hidden\\"></iframe>",
+      }
+    }
+  />
   <header
     className="hero"
   >
@@ -725,7 +732,7 @@ exports[`renders homepage unchanged 1`] = `
         <span>
           © Sparkbox
            
-          2022
+          2023
           .
            
         </span>

--- a/pages/index.js
+++ b/pages/index.js
@@ -24,7 +24,24 @@ const Home = ({ apprenticeData: { currentApprenticeGroup, previousApprenticeGrou
     <Head>
       <title>Sparkbox Apprentices</title>
       <link rel="icon" href="/favicon.ico" />
+      <script
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{
+          __html: `
+            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
+            var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
+            j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
+            f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KQ53HCR');
+          `,
+        }}
+      />
     </Head>
+    <noscript
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{
+        __html: '<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KQ53HCR" height="0" width="0" style="display:none;visibility:hidden"></iframe>',
+      }}
+    />
     <Hero />
     <main>
       <ApprenticeQualities />


### PR DESCRIPTION
### Description:

Adds Google Tag Manager so the Outreach team can collect Analytics data.

See Story: [SC-1719](https://sparkbox.atlassian.net/browse/SC-1719)

### To Validate:
1. Make sure all PR Checks have passed
2. Open the [Netlify Deploy Preview](https://deploy-preview-47--sb-apprentices.netlify.app/)
3. Inspect the code and confirm that you see Google Tag Manager scripts in the head, and a noscript in the body, that match the code snippets Kaitlyn gave us in the card

![apprentices-gtm](https://github.com/sparkbox/apprentices-page-next/assets/23404383/5416aa29-c05e-4124-8e4b-32f05e6f0e7f)


[SC-1719]: https://sparkbox.atlassian.net/browse/SC-1719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ