### PR TITLE
chore: add redirect for seesparkbox.com

### DIFF
--- a/__tests__/snapshot.js
+++ b/__tests__/snapshot.js
@@ -3,6 +3,9 @@ import renderer from 'react-test-renderer';
 import Index from '../pages/index';
 
 it('renders homepage unchanged', () => {
+  const mockFooterDate = new Date(2023, 0, 1);
+  jest.spyOn(global, 'Date').mockImplementation(() => mockFooterDate);
+
   const apprenticeData = {
     currentApprenticeGroup: {
       version: '0.0',

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,10 @@
 [[redirects]]
+  from = "https://apprentices.seesparkbox.com/*"
+  to = "https://apprentices.sparkbox.com/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/apply-dev.html"
   to = "/"
   status = 301


### PR DESCRIPTION
## Description

Adds a redirect rule to redirect `apprentices.seesparkbox.com` to `apprentices.sparkbox.com`. This rule would work in conjuction with the `ALIAS` record for `apprentices.seesparkbox.com` in DNSimple that points to the underlying Netlify site.

## Validation

1. The redirect structure can be validated by pasting the toml contents into https://redirects-playground.netlify.app/
2. Because this requires testing the TLD and our deploy previews use the Netlify URL, I'm unsure of how to test this other than merging and deploying. However, I believe that this can be safely tested in production without adverse affects on apprentices.sparkbox.com.


