### PR TITLE
chore: redirect index page for seesparkbox.com

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,12 @@
   force = true
 
 [[redirects]]
+  from = "https://apprentices.seesparkbox.com"
+  to = "https://apprentices.sparkbox.com"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/apply-dev.html"
   to = "/"
   status = 301


### PR DESCRIPTION
Description
Updates the  redirect rules to redirect apprentices.seesparkbox.com to apprentices.sparkbox.com. This rule works in conjunction with the CNAME record for apprentices.seesparkbox.com in DNSimple that points to the underlying Netlify site.

This update is necessary because the previous wildcard match in #49 only matched sub-pages. We don't actually have any subpages on the site any more, but the previous redirect can stay in order to redirect prior pages to sparkbox.com (eg https://apprentices.seesparkbox.com/apply-dev.html)

Validation
1. The redirect structure can be validated by pasting the toml contents into https://redirects-playground.netlify.app/
2. Because this requires testing the TLD and our deploy previews use the Netlify URL, there's not an easy way to test this other than merging and deploying. However, tested in production without adverse affects on apprentices.sparkbox.com.
3. The previously added redirect behavior in #49 can be observed by visiting https://apprentices.seesparkbox.com/apply-dev.html, which will redirect to https://apprentices.sparkbox.com/. 
    1. Issuing the following curl command will show that two `301` redirects are issued, first to https://apprentices.sparkbox.com/apply-dev.html (the redirect that was added in #49), then to `/` (the previously existing redirect).
    1. `curl -Lv https://apprentices.seesparkbox.com/apply-dev.html > /dev/null`